### PR TITLE
[preview-url] Carry on after previewing a URL, so that other modules can still work;

### DIFF
--- a/modules/preview-url.js
+++ b/modules/preview-url.js
@@ -106,7 +106,7 @@ function onMessage(say, from, chan, message) {
     }
   });
 
-  return utils.ABORT;
+  return utils.CARRY_ON;
 }
 
 module.exports = function(context, params) {


### PR DESCRIPTION
Otherwise, things like `!memo nick Check out http://nyan.cat :D` won't work.